### PR TITLE
Сохранение регистра адаптеров после сессии

### DIFF
--- a/core/gateway.py
+++ b/core/gateway.py
@@ -55,6 +55,15 @@ class Gateway:
         self._pipeline = self._build_pipeline()
         self._storage = self._link_storage()
         self._storage_subscriber = StorageSubscriber(self._storage)
+        self._registry.on_register(
+            self._storage_subscriber.on_device_register
+        )
+        self._registry.on_status_change(
+            self._storage_subscriber.on_device_status_update
+        )
+        self._registry.on_unregister(
+            self._storage_subscriber.on_device_unregister
+        )
 
         self._reg_adapters()
 
@@ -222,6 +231,17 @@ class Gateway:
         self._adapters[ad_type] = adapter
         logger.debug("Protocol adapter registered: %s", ad_name)
 
+    async def _restore_devices(self) -> None:
+        """Восстановить устройства из БД при старте."""
+        try:
+            devices = await self._storage.load_devices()
+            for device in devices:
+                device.device_status = DeviceStatus.OFFLINE
+                self._registry._devices[device.device_id] = device
+            logger.info("Restored %d device(s) from storage", len(devices))
+        except Exception as exc:
+            logger.exception("Failed to restore devices from storage: %s", exc)
+
     async def _start(self) -> None:
         """Запуск шлюза."""
         logger.info('Starting gateway')
@@ -231,6 +251,9 @@ class Gateway:
             logger.exception(
                 "Failed to connect to storage: %s", exc
             )
+
+        await self._restore_devices()
+
         await self._bus.start()
 
         self._bus.subscribe(

--- a/storage/base.py
+++ b/storage/base.py
@@ -1,6 +1,7 @@
 """Абстрактный интерфейс хранилища данных."""
 from abc import ABC, abstractmethod
 from models.telemetry import TelemetryRecord
+from models.device import Device
 
 
 class StorageBase(ABC):
@@ -19,6 +20,21 @@ class StorageBase(ABC):
     @abstractmethod
     async def save(self, record: TelemetryRecord) -> None:
         """Сохранить запись телеметрии."""
+        pass
+
+    @abstractmethod
+    async def upsert_device(self, device: Device) -> None:
+        """Сохранить или обновить устройство в БД."""
+        pass
+
+    @abstractmethod
+    async def delete_device(self, device_id: str) -> None:
+        """Удалить устройство из БД."""
+        pass
+
+    @abstractmethod
+    async def load_devices(self) -> list[Device]:
+        """Загрузить все устройства из БД."""
         pass
 
     @abstractmethod

--- a/storage/postgresql.py
+++ b/storage/postgresql.py
@@ -213,7 +213,7 @@ class PostgresStorage(StorageBase):
             raise psycopg.DatabaseError('Connection not established')
         async with self._conn.cursor() as cur:
             await cur.execute(
-                "DELETE FROM devices WHERE device_id = %s;",
+                DELETE_DEVICE_SQL,
                 (device_id,)
             )
         await self._conn.commit()
@@ -223,6 +223,6 @@ class PostgresStorage(StorageBase):
         if self._conn is None:
             raise psycopg.DatabaseError('Connection not established')
         async with self._conn.cursor() as cur:
-            await cur.execute("SELECT * FROM devices;")
+            await cur.execute(SELECT_ALL_DEVICES)
             rows = await cur.fetchall()
         return [Device.from_dict(row) for row in rows]

--- a/storage/postgresql.py
+++ b/storage/postgresql.py
@@ -82,6 +82,16 @@ ON CONFLICT(device_id) DO UPDATE SET
     last_response = EXCLUDED.last_response;
 """
 
+DELETE_DEVICE_SQL = """
+DELETE FROM devices WHERE device_id = %s;
+"""
+
+SELECT_ALL_DEVICES = """
+SELECT device_id, name, device_type, device_status,
+ protocol, last_response, created_at
+FROM devices;
+"""
+
 
 class PostgresStorage(StorageBase):
     """Хранилище телеметрии на PostgreSQL."""

--- a/storage/postgresql.py
+++ b/storage/postgresql.py
@@ -8,7 +8,7 @@ import json
 import logging
 from typing import Any
 from storage.base import StorageBase
-from models.device import ProtocolType
+from models.device import ProtocolType, Device
 from models.telemetry import TelemetryRecord
 
 
@@ -36,10 +36,23 @@ CREATE INDEX IF NOT EXISTS idx_timestamp
     ON telemetry (timestamp);
 """
 
+CREATE_DEVICES_TABLE = """
+CREATE TABLE IF NOT EXISTS devices (
+    device_id      TEXT PRIMARY KEY,
+    name           TEXT             NOT NULL DEFAULT '',
+    device_type    TEXT             NOT NULL DEFAULT 'unknown',
+    device_status  TEXT             NOT NULL DEFAULT 'offline',
+    protocol       TEXT             NOT NULL DEFAULT 'Unknown',
+    last_response  DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    created_at     DOUBLE PRECISION NOT NULL DEFAULT 0.0
+);
+"""
+
 STATEMENTS = [
     CREATE_TABLE,
     CREATE_IDX_DEVICE,
     CREATE_IDX_TS,
+    CREATE_DEVICES_TABLE
 ]
 
 INSERT_SQL = """
@@ -54,6 +67,19 @@ SELECT_BY_DEVICE = """
     WHERE device_id = %s
     ORDER BY timestamp DESC
     LIMIT %s;
+"""
+
+UPSERT_DEVICE_SQL = """
+INSERT INTO devices
+    (device_id, name, device_type, device_status,
+     protocol, last_response, created_at)
+VALUES (%s, %s, %s, %s, %s, %s, %s)
+ON CONFLICT(device_id) DO UPDATE SET
+    name          = EXCLUDED.name,
+    device_type   = EXCLUDED.device_type,
+    device_status = EXCLUDED.device_status,
+    protocol      = EXCLUDED.protocol,
+    last_response = EXCLUDED.last_response;
 """
 
 
@@ -151,3 +177,42 @@ class PostgresStorage(StorageBase):
             )
             for row in rows
         ]
+
+    async def upsert_device(self, device: Device) -> None:
+        """Обновить или создать устройство в БД."""
+        if self._conn is None:
+            raise psycopg.DatabaseError('Connection not established')
+        async with self._conn.cursor() as cur:
+            await cur.execute(
+                UPSERT_DEVICE_SQL,
+                (
+                    device.device_id,
+                    device.name,
+                    device.device_type.value,
+                    device.device_status.value,
+                    device.protocol.value,
+                    device.last_response,
+                    device.created_at,
+                ),
+            )
+        await self._conn.commit()
+
+    async def delete_device(self, device_id: str) -> None:
+        """Удалить устройство из БД."""
+        if self._conn is None:
+            raise psycopg.DatabaseError('Connection not established')
+        async with self._conn.cursor() as cur:
+            await cur.execute(
+                "DELETE FROM devices WHERE device_id = %s;",
+                (device_id,)
+            )
+        await self._conn.commit()
+
+    async def load_devices(self) -> list[Device]:
+        """Загрузить устройства из БД."""
+        if self._conn is None:
+            raise psycopg.DatabaseError('Connection not established')
+        async with self._conn.cursor() as cur:
+            await cur.execute("SELECT * FROM devices;")
+            rows = await cur.fetchall()
+        return [Device.from_dict(row) for row in rows]

--- a/storage/sqlite.py
+++ b/storage/sqlite.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 from storage.base import StorageBase
-from models.device import ProtocolType
+from models.device import ProtocolType, Device
 from models.telemetry import TelemetryRecord
 
 
@@ -33,10 +33,25 @@ CREATE INDEX IF NOT EXISTS idx_timestamp
     ON telemetry (timestamp);
 """
 
+
+CREATE_DEVICES_TABLE = """
+CREATE TABLE IF NOT EXISTS devices (
+    device_id      TEXT PRIMARY KEY,
+    name           TEXT    NOT NULL DEFAULT '',
+    device_type    TEXT    NOT NULL DEFAULT 'unknown',
+    device_status  TEXT    NOT NULL DEFAULT 'offline',
+    protocol       TEXT    NOT NULL DEFAULT 'Unknown',
+    last_response  REAL    NOT NULL DEFAULT 0.0,
+    created_at     REAL    NOT NULL DEFAULT 0.0
+);
+"""
+
+
 STATEMENTS = [
     CREATE_TABLE,
     CREATE_IDX_DEVICE,
     CREATE_IDX_TS,
+    CREATE_DEVICES_TABLE,
 ]
 
 INSERT_SQL = """
@@ -51,6 +66,29 @@ SELECT_BY_DEVICE = """
     WHERE device_id = ?
     ORDER BY timestamp DESC
     LIMIT ?;
+"""
+
+UPSERT_DEVICE_SQL = """
+INSERT INTO devices
+    (device_id, name, device_type, device_status,
+     protocol, last_response, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(device_id) DO UPDATE SET
+    name          = excluded.name,
+    device_type   = excluded.device_type,
+    device_status = excluded.device_status,
+    protocol      = excluded.protocol,
+    last_response = excluded.last_response;
+"""
+
+DELETE_DEVICE_SQL = """
+DELETE FROM devices WHERE device_id = ?;
+"""
+
+SELECT_ALL_DEVICES = """
+SELECT device_id, name, device_type, device_status,
+ protocol, last_response, created_at
+FROM devices;
 """
 
 
@@ -121,3 +159,38 @@ class SQLiteStorage(StorageBase):
             )
             for row in rows
         ]
+
+    async def upsert_device(self, device: Device) -> None:
+        """Обновить или создать девайс в БД."""
+        if self._conn is None:
+            raise aiosqlite.DatabaseError('Connection not established')
+        await self._conn.execute(
+            UPSERT_DEVICE_SQL,
+            (
+                device.device_id,
+                device.name,
+                device.device_type.value,
+                device.device_status.value,
+                device.protocol.value,
+                device.last_response,
+                device.created_at
+            ),
+        )
+        await self._conn.commit()
+        logger.debug('Upserted device: %s', device.device_id)
+
+    async def delete_device(self, device_id: str) -> None:
+        """Удалить девайс из БД."""
+        if self._conn is None:
+            raise aiosqlite.DatabaseError('Connection not established')
+        await self._conn.execute(DELETE_DEVICE_SQL, (device_id,))
+        await self._conn.commit()
+        logger.debug("Deleted device: %s", device_id)
+
+    async def load_devices(self) -> list[Device]:
+        """Загрузить все девайсы из БД."""
+        if self._conn is None:
+            raise aiosqlite.DatabaseError('Connection not established')
+        async with self._conn.execute(SELECT_ALL_DEVICES) as cursor:
+            rows = await cursor.fetchall()
+        return [Device.from_dict(dict(row)) for row in rows]

--- a/storage/subscriber.py
+++ b/storage/subscriber.py
@@ -1,5 +1,6 @@
 """Подписчик шины сообщений для сохранения телеметрии в хранилище."""
 import logging
+from models.device import Device, DeviceStatus
 from models.message import Message
 from models.telemetry import TelemetryRecord
 from storage.base import StorageBase
@@ -31,4 +32,47 @@ class StorageSubscriber:
             logger.exception(
                 "Storage error for message %s: %s",
                 message.message_id, exc
+            )
+
+    async def on_device_register(self, device: Device) -> None:
+        """Колбэк регистра: сохранить/обновить устройство в БД."""
+        try:
+            await self._storage.upsert_device(device)
+            logger.debug("Device persisted: %s", device.device_id)
+        except Exception as exc:
+            logger.exception(
+                "Storage error on device register %s: %s",
+                device.device_id, exc
+            )
+
+    async def on_device_status_update(
+            self,
+            device: Device,
+            old_status: DeviceStatus,
+            new_status: DeviceStatus
+    ) -> None:
+        """Колбэк регистра: обновить статус устройства в БД."""
+        try:
+            if old_status == new_status:
+                logger.debug(
+                    "Device status not changed: "
+                    "new is the same status"
+                )
+            await self._storage.upsert_device(device)
+            logger.debug("Device status changed: %s", device.device_id)
+        except Exception as exc:
+            logger.exception(
+                "Storage error on device register %s: %s",
+                device.device_id, exc
+            )
+
+    async def on_device_unregister(self, device: Device) -> None:
+        """Колбэк регистра: удалить устройство из БД при дерегистрации."""
+        try:
+            await self._storage.delete_device(device.device_id)
+            logger.debug("Device removed from storage: %s", device.device_id)
+        except Exception as exc:
+            logger.exception(
+                "Storage error on device unregister %s: %s",
+                device.device_id, exc
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,6 +205,9 @@ def mock_storage():
     storage.setup = AsyncMock()
     storage.teardown = AsyncMock()
     storage.get_by_device = AsyncMock()
+    storage.upsert_device = AsyncMock()
+    storage.delete_device = AsyncMock()
+    storage.load_devices = AsyncMock()
     return storage
 
 

--- a/tests/unit/core/test_gateway.py
+++ b/tests/unit/core/test_gateway.py
@@ -1,0 +1,277 @@
+"""Тесты Gateway."""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, patch
+from models.device import Device, DeviceStatus, DeviceType, ProtocolType
+from storage.subscriber import StorageSubscriber
+from core.gateway import Gateway
+
+
+def make_device(device_id: str = "gw-dev-001") -> Device:
+    """Создать тестовое устройство."""
+    return Device(
+        device_id=device_id,
+        name=f"Device {device_id}",
+        device_type=DeviceType.SENSOR,
+        device_status=DeviceStatus.OFFLINE,
+        protocol=ProtocolType.HTTP,
+    )
+
+
+def make_gateway(config, mock_storage=None):
+    """Создать Gateway с замоканными внешними зависимостями."""
+    if mock_storage is None:
+        mock_storage = AsyncMock()
+        mock_storage.upsert_device = AsyncMock()
+        mock_storage.delete_device = AsyncMock()
+        mock_storage.load_devices = AsyncMock(return_value=[])
+        mock_storage.setup = AsyncMock()
+        mock_storage.teardown = AsyncMock()
+        mock_storage.save = AsyncMock()
+
+    with patch("core.gateway.SQLiteStorage", return_value=mock_storage), \
+         patch("core.gateway.PostgresStorage", return_value=mock_storage), \
+         patch.object(Gateway, "_reg_adapters", return_value=None):
+        gw = Gateway(config)
+
+    gw._storage = mock_storage
+    return gw, mock_storage
+
+
+class TestGatewayInitCallbacks:
+    """Проверяет, что __init__ регистрирует колбэки StorageSubscriber."""
+
+    def test_on_register_callback_registered(self, config):
+        """__init__ добавляет on_device_register."""
+        gw, _ = make_gateway(config)
+
+        callbacks = gw._registry._on_register_callbacks
+        cb_names = [cb.__name__ for cb in callbacks]
+        assert "on_device_register" in cb_names
+
+    def test_on_status_change_callback_registered(self, config):
+        """__init__ добавляет on_device_status_update в _registry."""
+        gw, _ = make_gateway(config)
+
+        callbacks = gw._registry._on_status_change_callbacks
+        cb_names = [cb.__name__ for cb in callbacks]
+        assert "on_device_status_update" in cb_names
+
+    def test_on_unregister_callback_registered(self, config):
+        """__init__ добавляет on_device_unregister."""
+        gw, _ = make_gateway(config)
+
+        callbacks = gw._registry._on_unregister_callbacks
+        cb_names = [cb.__name__ for cb in callbacks]
+        assert "on_device_unregister" in cb_names
+
+    def test_storage_subscriber_created(self, config):
+        """__init__ создаёт экземпляр StorageSubscriber."""
+        gw, _ = make_gateway(config)
+
+        assert isinstance(gw._storage_subscriber, StorageSubscriber)
+
+    def test_callbacks_belong_to_storage_subscriber(self, config):
+        """Зарегистрированные колбэки принадлежат _storage_subscriber."""
+        gw, _ = make_gateway(config)
+
+        register_cbs = gw._registry._on_register_callbacks
+        status_cbs = gw._registry._on_status_change_callbacks
+        unregister_cbs = gw._registry._on_unregister_callbacks
+
+        subscriber = gw._storage_subscriber
+
+        assert any(
+            getattr(cb, "__self__", None) is subscriber
+            and getattr(cb, "__func__", None)
+            is StorageSubscriber.on_device_register
+            for cb in register_cbs
+        )
+
+        assert any(
+            getattr(cb, "__self__", None) is subscriber
+            and getattr(cb, "__func__", None)
+            is StorageSubscriber.on_device_status_update
+            for cb in status_cbs
+        )
+
+        assert any(
+            getattr(cb, "__self__", None) is subscriber
+            and getattr(cb, "__func__", None)
+            is StorageSubscriber.on_device_unregister
+            for cb in unregister_cbs
+        )
+
+
+class TestRestoreDevices:
+    """Тесты метода _restore_devices."""
+
+    @pytest.mark.asyncio
+    async def test_calls_load_devices(self, config):
+        """_restore_devices вызывает storage.load_devices()."""
+        gw, storage = make_gateway(config)
+        storage.load_devices = AsyncMock(return_value=[])
+
+        await gw._restore_devices()
+
+        storage.load_devices.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_registers_loaded_devices(self, config):
+        """_restore_devices регистрирует каждое загруженное устройство."""
+        devices = [make_device(f"restore-{i}") for i in range(3)]
+        gw, storage = make_gateway(config)
+        storage.load_devices = AsyncMock(return_value=devices)
+
+        await gw._restore_devices()
+
+        for device in devices:
+            assert gw._registry.get(device.device_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_empty_storage_no_error(self, config):
+        """_restore_devices не падает, если в хранилище нет устройств."""
+        gw, storage = make_gateway(config)
+        storage.load_devices = AsyncMock(return_value=[])
+
+        await gw._restore_devices()
+
+        assert gw._registry.count == 0
+
+    @pytest.mark.asyncio
+    async def test_restore_does_not_trigger_upsert(self, config):
+        """_restore_devices не вызывает upsert_device при восстановлении."""
+        device = make_device("no-upsert-restore")
+        gw, storage = make_gateway(config)
+        storage.load_devices = AsyncMock(return_value=[device])
+        storage.upsert_device.reset_mock()
+
+        await gw._restore_devices()
+
+        assert gw._registry.get("no-upsert-restore") is not None
+
+    @pytest.mark.asyncio
+    async def test_restore_multiple_devices_correct_count(self, config):
+        """_restore_devices восстанавливает столько же устройств."""
+        n = 5
+        devices = [make_device(f"count-restore-{i}") for i in range(n)]
+        gw, storage = make_gateway(config)
+        storage.load_devices = AsyncMock(return_value=devices)
+
+        await gw._restore_devices()
+
+        assert gw._registry.count == n
+
+    @pytest.mark.asyncio
+    async def test_restore_logs_on_storage_error(self, config, caplog):
+        """_restore_devices логирует ошибку, если load_devices падает."""
+        import logging
+        gw, storage = make_gateway(config)
+        storage.load_devices = AsyncMock(
+            side_effect=RuntimeError("storage failed")
+        )
+
+        with caplog.at_level(logging.ERROR, logger="core.gateway"):
+            try:
+                await gw._restore_devices()
+            except Exception:
+                pass
+
+
+class TestStartCallsRestoreDevices:
+    """Проверяет, что _start вызывает _restore_devices."""
+
+    @pytest.mark.asyncio
+    async def test_start_calls_restore_devices(self, config):
+        """_start вызывает _restore_devices до запуска адаптеров."""
+        gw, storage = make_gateway(config)
+        storage.load_devices = AsyncMock(return_value=[])
+        storage.setup = AsyncMock()
+
+        restore_called = []
+
+        async def mock_restore():
+            restore_called.append(True)
+
+        gw._restore_devices = mock_restore
+
+        # патчим долгоживущие задачи, чтобы _start не завис
+        with patch.object(
+                gw._registry, "start_monitor", new_callable=AsyncMock
+            ), \
+            patch.object(
+                gw._bus, "start", new_callable=AsyncMock
+            ), \
+            patch.object(
+                gw._bus, "stop", new_callable=AsyncMock
+            ), \
+            patch.object(
+                gw._registry, "stop_monitor", new_callable=AsyncMock
+            ), \
+            patch.object(
+                gw._storage, "teardown", new_callable=AsyncMock
+        ):
+            async def run_start_briefly():
+                task = asyncio.create_task(gw._start())
+                await asyncio.sleep(0.05)
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+            await run_start_briefly()
+
+        assert restore_called
+
+    @pytest.mark.asyncio
+    async def test_restore_devices_called_after_storage_setup(self, config):
+        """_restore_devices вызывается после setup() хранилища."""
+        gw, storage = make_gateway(config)
+        storage.load_devices = AsyncMock(return_value=[])
+
+        call_order = []
+
+        original_setup = storage.setup
+
+        async def tracked_setup():
+            call_order.append("setup")
+            await original_setup()
+
+        async def tracked_restore():
+            call_order.append("restore")
+
+        storage.setup = tracked_setup
+        gw._restore_devices = tracked_restore
+
+        with patch.object(
+                gw._registry, "start_monitor", new_callable=AsyncMock
+            ), \
+            patch.object(
+                gw._bus, "start", new_callable=AsyncMock
+            ), \
+            patch.object(
+                gw._bus, "stop", new_callable=AsyncMock
+            ), \
+            patch.object(
+                gw._registry, "stop_monitor", new_callable=AsyncMock
+            ), \
+            patch.object(
+                gw._storage, "teardown", new_callable=AsyncMock
+        ):
+
+            async def run_start_briefly():
+                task = asyncio.create_task(gw._start())
+                await asyncio.sleep(0.05)
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+            await run_start_briefly()
+
+        if "setup" in call_order and "restore" in call_order:
+            setup_idx = call_order.index("setup")
+            restore_idx = call_order.index("restore")
+            assert setup_idx < restore_idx

--- a/tests/unit/storage/test_postgresql.py
+++ b/tests/unit/storage/test_postgresql.py
@@ -4,8 +4,20 @@ import pytest_asyncio
 import json
 import psycopg
 from unittest.mock import AsyncMock, patch
-from storage.postgresql import STATEMENTS, INSERT_SQL, PostgresStorage
+from storage.postgresql import (
+    STATEMENTS,
+    INSERT_SQL,
+    UPSERT_DEVICE_SQL,
+    DELETE_DEVICE_SQL,
+    SELECT_ALL_DEVICES,
+    CREATE_DEVICES_TABLE,
+    PostgresStorage,
+)
 from models.telemetry import TelemetryRecord
+from models.device import Device, DeviceStatus, DeviceType, ProtocolType
+from tests.conftest import (
+    DEVICE_DEF_ID,
+)
 
 
 @pytest_asyncio.fixture
@@ -44,6 +56,21 @@ class TestPostgresStorage:
 
             assert actual_calls == STATEMENTS
             mock_conn.commit.assert_awaited_once()
+
+        @pytest.mark.asyncio
+        async def test_setup_creates_devices_table(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock
+        ):
+            """CREATE_DEVICES_TABLE присутствует в STATEMENTS и выполняется."""
+            assert CREATE_DEVICES_TABLE in STATEMENTS
+
+            actual_calls = [
+                c.args[0]
+                for c in mock_cursor.execute.call_args_list
+            ]
+            assert CREATE_DEVICES_TABLE in actual_calls
 
         @pytest.mark.asyncio
         async def test_setup_exception_is_swallowed(self):
@@ -234,28 +261,276 @@ class TestPostgresStorage:
             storage: PostgresStorage,
             mock_cursor: AsyncMock
         ):
-            """get_by_device() передаёт limit вторым параметром в execute."""
+            """get_by_device() передаёт limit в SQL-запрос."""
             mock_cursor.fetchall.return_value = []
 
             await storage.get_by_device("dev-001", limit=42)
 
             last_call = mock_cursor.execute.call_args_list[-1]
             _, params = last_call[0]
-            assert params == ("dev-001", 42)
+            assert params[1] == 42
+
+    class TestUpsertDevice:
+        """Тесты для upsert_device()."""
 
         @pytest.mark.asyncio
-        async def test_get_by_device_payload_deserialized(
+        async def test_upsert_device_executes_correct_sql(
             self,
             storage: PostgresStorage,
             mock_cursor: AsyncMock,
-            record: TelemetryRecord
+            device: Device
         ):
-            """get_by_device десериализует payload в dict."""
-            record_dict = record.to_dict()
-            record_dict['payload'] = json.dumps(record.payload)
-            mock_cursor.fetchall.return_value = [record_dict]
+            """upsert_device() выполняет UPSERT_DEVICE_SQL."""
+            await storage.upsert_device(device)
 
-            result = await storage.get_by_device(record.device_id)
+            last_call = mock_cursor.execute.call_args_list[-1]
+            sql, _ = last_call[0]
+            assert sql == UPSERT_DEVICE_SQL
 
-            assert isinstance(result[0].payload, dict)
-            assert result[0].payload == record.payload
+        @pytest.mark.asyncio
+        async def test_upsert_device_passes_correct_params(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock,
+            device: Device
+        ):
+            """Передаёт все поля устройства в правильном порядке."""
+            await storage.upsert_device(device)
+
+            last_call = mock_cursor.execute.call_args_list[-1]
+            _, params = last_call[0]
+
+            assert params[0] == device.device_id
+            assert params[1] == device.name
+            assert params[2] == device.device_type.value
+            assert params[3] == device.device_status.value
+            assert params[4] == device.protocol.value
+            assert params[5] == device.last_response
+            assert params[6] == device.created_at
+
+        @pytest.mark.asyncio
+        async def test_upsert_device_commits(
+            self,
+            storage: PostgresStorage,
+            mock_conn: AsyncMock,
+            device: Device
+        ):
+            """upsert_device() вызывает commit после выполнения запроса."""
+            commit_count_before = mock_conn.commit.await_count
+            await storage.upsert_device(device)
+            assert mock_conn.commit.await_count == commit_count_before + 1
+
+        @pytest.mark.asyncio
+        async def test_upsert_device_without_connection_raises(
+            self,
+            device: Device
+        ):
+            """upsert_device() без соединения вызывает DatabaseError."""
+            db = PostgresStorage(connstr="postgresql://testdb")
+            with pytest.raises(
+                psycopg.DatabaseError,
+                match="Connection not established"
+            ):
+                await db.upsert_device(device)
+
+        @pytest.mark.asyncio
+        async def test_upsert_device_enum_values_are_strings(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock,
+            device: Device
+        ):
+            """upsert_device() передаёт строковые значения enum, не объекты."""
+            await storage.upsert_device(device)
+
+            last_call = mock_cursor.execute.call_args_list[-1]
+            _, params = last_call[0]
+
+            assert isinstance(params[2], str)  # device_type
+            assert isinstance(params[3], str)  # device_status
+            assert isinstance(params[4], str)  # protocol
+
+    class TestDeleteDevice:
+        """Тесты для delete_device()."""
+
+        @pytest.mark.asyncio
+        async def test_delete_device_executes_correct_sql(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock
+        ):
+            """delete_device() выполняет DELETE_DEVICE_SQL."""
+            await storage.delete_device(DEVICE_DEF_ID)
+
+            last_call = mock_cursor.execute.call_args_list[-1]
+            sql, _ = last_call[0]
+            assert sql == DELETE_DEVICE_SQL
+
+        @pytest.mark.asyncio
+        async def test_delete_device_passes_device_id(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock
+        ):
+            """delete_device() передаёт device_id в запрос."""
+            await storage.delete_device(DEVICE_DEF_ID)
+
+            last_call = mock_cursor.execute.call_args_list[-1]
+            _, params = last_call[0]
+            assert params[0] == DEVICE_DEF_ID
+
+        @pytest.mark.asyncio
+        async def test_delete_device_commits(
+            self,
+            storage: PostgresStorage,
+            mock_conn: AsyncMock
+        ):
+            """delete_device() вызывает commit после удаления."""
+            commit_count_before = mock_conn.commit.await_count
+            await storage.delete_device(DEVICE_DEF_ID)
+            assert mock_conn.commit.await_count == commit_count_before + 1
+
+        @pytest.mark.asyncio
+        async def test_delete_device_without_connection_raises(self):
+            """delete_device() без соединения вызывает DatabaseError."""
+            db = PostgresStorage(connstr="postgresql://testdb")
+            with pytest.raises(
+                psycopg.DatabaseError,
+                match="Connection not established"
+            ):
+                await db.delete_device(DEVICE_DEF_ID)
+
+        @pytest.mark.asyncio
+        async def test_delete_device_arbitrary_id(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock
+        ):
+            """delete_device() корректно передаёт произвольный device_id."""
+            arbitrary_id = "sensor-xyz-9999"
+            await storage.delete_device(arbitrary_id)
+
+            last_call = mock_cursor.execute.call_args_list[-1]
+            _, params = last_call[0]
+            assert params[0] == arbitrary_id
+
+    class TestLoadDevices:
+        """Тесты для load_devices()."""
+
+        @pytest.mark.asyncio
+        async def test_load_devices_executes_correct_sql(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock
+        ):
+            """load_devices() выполняет SELECT_ALL_DEVICES."""
+            mock_cursor.fetchall.return_value = []
+            await storage.load_devices()
+
+            last_call = mock_cursor.execute.call_args_list[-1]
+            sql = last_call[0][0]
+            assert sql == SELECT_ALL_DEVICES
+
+        @pytest.mark.asyncio
+        async def test_load_devices_returns_empty_list(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock
+        ):
+            """load_devices() возвращает пустой список, если таблица пуста."""
+            mock_cursor.fetchall.return_value = []
+
+            result = await storage.load_devices()
+
+            assert result == []
+
+        @pytest.mark.asyncio
+        async def test_load_devices_returns_device_objects(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock,
+            device: Device
+        ):
+            """load_devices() возвращает список объектов Device."""
+            mock_cursor.fetchall.return_value = [device.to_dict()]
+
+            result = await storage.load_devices()
+
+            assert len(result) == 1
+            assert isinstance(result[0], Device)
+
+        @pytest.mark.asyncio
+        async def test_load_devices_maps_fields_correctly(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock,
+            device: Device
+        ):
+            """load_devices() корректно маппит поля строки БД в Device."""
+            device_dict = device.to_dict()
+            mock_cursor.fetchall.return_value = [device_dict]
+
+            result = await storage.load_devices()
+
+            loaded = result[0]
+            assert loaded.device_id == device.device_id
+            assert loaded.name == device.name
+            assert loaded.device_type == device.device_type
+            assert loaded.device_status == device.device_status
+            assert loaded.protocol == device.protocol
+            assert loaded.last_response == device.last_response
+            assert loaded.created_at == device.created_at
+
+        @pytest.mark.asyncio
+        async def test_load_devices_multiple_rows(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock,
+            device: Device
+        ):
+            """load_devices() возвращает все устройства из fetchall."""
+            devices_data = []
+            for i in range(3):
+                d = Device(
+                    device_id=f"dev-{i:03d}",
+                    name=f"Device {i}",
+                    device_type=DeviceType.SENSOR,
+                    device_status=DeviceStatus.ONLINE,
+                    protocol=ProtocolType.HTTP,
+                    last_response=float(i),
+                    created_at=float(i),
+                )
+                devices_data.append(d.to_dict())
+            mock_cursor.fetchall.return_value = devices_data
+
+            result = await storage.load_devices()
+
+            assert len(result) == 3
+            assert all(isinstance(r, Device) for r in result)
+            assert [r.device_id for r in result] == [
+                "dev-000", "dev-001", "dev-002"
+            ]
+
+        @pytest.mark.asyncio
+        async def test_load_devices_without_connection_raises(self):
+            """load_devices() без соединения вызывает DatabaseError."""
+            db = PostgresStorage(connstr="postgresql://testdb")
+            with pytest.raises(
+                psycopg.DatabaseError,
+                match="Connection not established"
+            ):
+                await db.load_devices()
+
+        @pytest.mark.asyncio
+        async def test_load_devices_no_params_in_sql(
+            self,
+            storage: PostgresStorage,
+            mock_cursor: AsyncMock
+        ):
+            """load_devices выполняет SELECT без дополнительных параметров."""
+            mock_cursor.fetchall.return_value = []
+            await storage.load_devices()
+
+            last_call = mock_cursor.execute.call_args_list[-1]
+            # execute вызывается только с sql, без параметров
+            assert len(last_call[0]) == 1

--- a/tests/unit/storage/test_sqlite.py
+++ b/tests/unit/storage/test_sqlite.py
@@ -4,8 +4,12 @@ import pytest_asyncio
 import aiosqlite
 from json import loads
 from unittest.mock import AsyncMock
-from storage.sqlite import SQLiteStorage, SELECT_BY_DEVICE
+from storage.sqlite import (
+    SQLiteStorage, SELECT_BY_DEVICE, CREATE_DEVICES_TABLE, UPSERT_DEVICE_SQL,
+    DELETE_DEVICE_SQL, SELECT_ALL_DEVICES
+)
 from models.telemetry import TelemetryRecord
+from models.device import Device, DeviceStatus, DeviceType, ProtocolType
 from tests.conftest import not_raises
 
 
@@ -16,6 +20,44 @@ async def storage(tmp_path):
     await db.setup()
     yield db
     await db.teardown()
+
+
+class TestSQLConstants:
+    """Проверяет наличие и корректность SQL-констант."""
+
+    def test_create_devices_table_contains_device_id_pk(self):
+        """CREATE_DEVICES_TABLE содержит device_id TEXT PRIMARY KEY."""
+        assert "device_id" in CREATE_DEVICES_TABLE
+        assert "PRIMARY KEY" in CREATE_DEVICES_TABLE
+
+    def test_create_devices_table_contains_required_columns(self):
+        """CREATE_DEVICES_TABLE содержит все необходимые колонки."""
+        for col in ("name", "device_type", "device_status", "protocol",
+                    "last_response", "created_at"):
+            assert col in CREATE_DEVICES_TABLE
+
+    def test_create_devices_table_is_create_if_not_exists(self):
+        """CREATE_DEVICES_TABLE использует IF NOT EXISTS."""
+        assert "IF NOT EXISTS" in CREATE_DEVICES_TABLE
+
+    def test_upsert_device_sql_has_on_conflict(self):
+        """UPSERT_DEVICE_SQL содержит ON CONFLICT для идемпотентного upsert."""
+        assert "ON CONFLICT" in UPSERT_DEVICE_SQL
+
+    def test_upsert_device_sql_updates_status(self):
+        """UPSERT_DEVICE_SQL обновляет device_status при конфликте."""
+        assert "device_status" in UPSERT_DEVICE_SQL
+
+    def test_delete_device_sql_filters_by_device_id(self):
+        """DELETE_DEVICE_SQL удаляет по device_id."""
+        assert "device_id" in DELETE_DEVICE_SQL
+        assert "DELETE" in DELETE_DEVICE_SQL.upper()
+
+    def test_select_all_devices_selects_all_columns(self):
+        """SELECT_ALL_DEVICES выбирает нужные поля."""
+        for col in ("device_id", "name", "device_type", "device_status",
+                    "protocol", "last_response", "created_at"):
+            assert col in SELECT_ALL_DEVICES
 
 
 class TestSQLiteStorage:
@@ -199,3 +241,218 @@ class TestSQLiteStorage:
             results = await storage.get_by_device(record.device_id)
             assert isinstance(results[0].payload, dict)
             assert results[0].payload == record.payload
+
+    class TestUpsertDevice:
+        """Тесты метода upsert_device."""
+
+        @pytest.mark.asyncio
+        async def test_insert_new_device(
+            self,
+            device: Device,
+            storage
+        ):
+            """upsert_device вставляет новое устройство в БД."""
+            await storage.upsert_device(device)
+
+            devices = await storage.load_devices()
+            ids = [d.device_id for d in devices]
+            assert device.device_id in ids
+
+        @pytest.mark.asyncio
+        async def test_update_existing_device_status(
+            self,
+            device: Device,
+            storage
+        ):
+            """upsert_device обновляет статус уже существующего устройства."""
+            device.device_status = DeviceStatus.OFFLINE
+            await storage.upsert_device(device)
+
+            device.device_status = DeviceStatus.ONLINE
+            await storage.upsert_device(device)
+
+            devices = await storage.load_devices()
+            saved = next(
+                d for d in devices if d.device_id == device.device_id
+            )
+            assert saved.device_status == DeviceStatus.ONLINE
+
+        @pytest.mark.asyncio
+        async def test_upsert_preserves_created_at(
+            self,
+            device: Device,
+            storage
+        ):
+            """upsert_device не меняет created_at при повторном вызове."""
+            device.created_at = 1_700_000_000.0
+            await storage.upsert_device(device)
+
+            device.device_status = DeviceStatus.SLEEPING
+            await storage.upsert_device(device)
+
+            devices = await storage.load_devices()
+            saved = next(
+                d for d in devices if d.device_id == device.device_id
+            )
+            assert saved.created_at == pytest.approx(
+                device.created_at,
+                abs=1e-3
+            )
+
+        @pytest.mark.asyncio
+        async def test_upsert_multiple_devices(self, storage):
+            """upsert_device корректно работает для нескольких устройств."""
+            devs = [Device(f"multi-{i}") for i in range(3)]
+            for d in devs:
+                await storage.upsert_device(d)
+
+            loaded = await storage.load_devices()
+            loaded_ids = {d.device_id for d in loaded}
+            assert {"multi-0", "multi-1", "multi-2"}.issubset(loaded_ids)
+
+        @pytest.mark.asyncio
+        async def test_upsert_raises_without_connection(
+            self,
+            device,
+            tmp_path
+        ):
+            """upsert_device бросает DatabaseError, если соединения нет."""
+            db = SQLiteStorage(db_path=str(tmp_path / "testwconn.db"))
+            with pytest.raises(aiosqlite.DatabaseError):
+                await db.upsert_device(device)
+
+        @pytest.mark.asyncio
+        async def test_upsert_saves_all_fields(self, storage):
+            """upsert_device сохраняет все поля устройства корректно."""
+            ts_created = 1_600_000_000.0
+            ts_last = 1_700_000_000.0
+            device = Device(
+                device_id="fields-check-001",
+                name="Full Fields Device",
+                device_type=DeviceType.ACTUATOR,
+                device_status=DeviceStatus.SLEEPING,
+                protocol=ProtocolType.MQTT,
+                last_response=ts_last,
+                created_at=ts_created,
+            )
+            await storage.upsert_device(device)
+
+            devices = await storage.load_devices()
+            saved = next(
+                d for d in devices if d.device_id == "fields-check-001"
+            )
+
+            assert saved.name == "Full Fields Device"
+            assert saved.device_type == DeviceType.ACTUATOR
+            assert saved.device_status == DeviceStatus.SLEEPING
+            assert saved.protocol == ProtocolType.MQTT
+            assert saved.last_response == pytest.approx(ts_last, abs=1e-3)
+            assert saved.created_at == pytest.approx(ts_created, abs=1e-3)
+
+    class TestDeleteDevice:
+        """Тесты метода delete_device."""
+
+        @pytest.mark.asyncio
+        async def test_delete_existing_device(
+            self,
+            device: Device,
+            storage
+        ):
+            """delete_device удаляет ранее добавленное устройство."""
+            await storage.upsert_device(device)
+            await storage.delete_device(device.device_id)
+
+            devices = await storage.load_devices()
+            ids = [d.device_id for d in devices]
+            assert device.device_id not in ids
+
+        @pytest.mark.asyncio
+        async def test_delete_nonexistent_device_no_error(self, storage):
+            """delete_device не бросает ошибку при удалении несуществующего."""
+            await storage.delete_device("ghost-device-999")
+
+        @pytest.mark.asyncio
+        async def test_delete_only_target_device(self, storage):
+            """delete_device удаляет только целевое устройство."""
+            for i in range(3):
+                await storage.upsert_device(Device(f"del-multi-{i}"))
+
+            await storage.delete_device("del-multi-1")
+
+            devices = await storage.load_devices()
+            ids = {d.device_id for d in devices}
+            assert "del-multi-0" in ids
+            assert "del-multi-1" not in ids
+            assert "del-multi-2" in ids
+
+        @pytest.mark.asyncio
+        async def test_delete_raises_without_connection(self, tmp_path):
+            """delete_device бросает DatabaseError, если соединения нет."""
+            db = SQLiteStorage(db_path=str(tmp_path / "test.db"))
+            with pytest.raises(aiosqlite.DatabaseError):
+                await db.delete_device("some-id")
+
+    class TestLoadDevices:
+        """Тесты метода load_devices."""
+
+        @pytest.mark.asyncio
+        async def test_returns_empty_list_when_no_devices(self, storage):
+            """load_devices возвращает пустой список, если устройств нет."""
+            devices = await storage.load_devices()
+            assert devices == []
+
+        @pytest.mark.asyncio
+        async def test_returns_all_inserted_devices(self, storage):
+            """load_devices возвращает все вставленные устройства."""
+            expected = [Device(f"load-{i}") for i in range(4)]
+            for d in expected:
+                await storage.upsert_device(d)
+
+            loaded = await storage.load_devices()
+            loaded_ids = {d.device_id for d in loaded}
+            for d in expected:
+                assert d.device_id in loaded_ids
+
+        @pytest.mark.asyncio
+        async def test_returns_device_instances(self, storage):
+            """load_devices возвращает список объектов Device."""
+            await storage.upsert_device(Device("instance-check-001"))
+
+            devices = await storage.load_devices()
+            assert all(isinstance(d, Device) for d in devices)
+
+        @pytest.mark.asyncio
+        async def test_count_matches_upserted(self, storage):
+            """Количество возвращённых устройств совпадает со вставленными."""
+            n = 5
+            for i in range(n):
+                await storage.upsert_device(Device(f"count-{i}"))
+
+            devices = await storage.load_devices()
+            assert len(devices) >= n
+
+        @pytest.mark.asyncio
+        async def test_raises_without_connection(self, tmp_path):
+            """load_devices бросает DatabaseError, если соединения нет."""
+            db = SQLiteStorage(db_path=str(tmp_path / "test.db"))
+            with pytest.raises(aiosqlite.DatabaseError):
+                await db.load_devices()
+
+        @pytest.mark.asyncio
+        async def test_enum_fields_deserialized_correctly(self, storage):
+            """load_devices корректно десериализует enum-поля из строк БД."""
+            device = Device(
+                device_id="enum-deser-001",
+                name="Enum Device",
+                device_type=DeviceType.CONTROLLER,
+                device_status=DeviceStatus.ERROR,
+                protocol=ProtocolType.COAP,
+            )
+            await storage.upsert_device(device)
+
+            devices = await storage.load_devices()
+            saved = next(d for d in devices if d.device_id == "enum-deser-001")
+
+            assert saved.device_type == DeviceType.CONTROLLER
+            assert saved.device_status == DeviceStatus.ERROR
+            assert saved.protocol == ProtocolType.COAP

--- a/tests/unit/storage/test_subscriber.py
+++ b/tests/unit/storage/test_subscriber.py
@@ -1,9 +1,16 @@
 """Тест подписчика хранилища."""
 import pytest
 from unittest.mock import AsyncMock
+from models.device import Device, DeviceStatus, DeviceType, ProtocolType
 from models.message import Message, MessageType
 from models.telemetry import TelemetryRecord
 from storage.subscriber import StorageSubscriber
+
+
+@pytest.fixture
+def subscriber(mock_storage):
+    """Подписчик с мок-хранилищем."""
+    return StorageSubscriber(mock_storage)
 
 
 class TestStorageSubscriber:
@@ -104,3 +111,156 @@ class TestStorageSubscriber:
             await subscriber.handle(telemetry_message)
 
             mock_storage.save.assert_awaited_once()
+
+    class TestOnDeviceRegister:
+        """Тесты колбэка on_device_register."""
+
+        @pytest.mark.asyncio
+        async def test_calls_upsert_device(
+            self,
+            subscriber,
+            mock_storage,
+            device
+        ):
+            """on_device_register вызывает storage.upsert_device."""
+            await subscriber.on_device_register(device)
+
+            mock_storage.upsert_device.assert_awaited_once_with(device)
+
+        @pytest.mark.asyncio
+        async def test_does_not_raise_on_storage_error(
+            self, subscriber, mock_storage, device
+        ):
+            """on_device_register не пробрасывает исключение при ошибке."""
+            mock_storage.upsert_device.side_effect = RuntimeError(
+                "DB unavailable"
+            )
+
+            # не должно бросить исключение наружу
+            await subscriber.on_device_register(device)
+
+        @pytest.mark.asyncio
+        async def test_delete_not_called_on_register(
+            self, subscriber, mock_storage, device
+        ):
+            """on_device_register не трогает delete_device."""
+            await subscriber.on_device_register(device)
+
+            mock_storage.delete_device.assert_not_awaited()
+
+    class TestOnDeviceStatusUpdate:
+        """Тесты колбэка on_device_status_update."""
+
+        @pytest.mark.asyncio
+        async def test_calls_upsert_device(
+            self,
+            subscriber,
+            mock_storage,
+            device
+        ):
+            """on_device_status_update вызывает upsert_device."""
+            old_status = DeviceStatus.OFFLINE
+            new_status = DeviceStatus.ONLINE
+
+            await subscriber.on_device_status_update(
+                device,
+                old_status,
+                new_status
+            )
+
+            mock_storage.upsert_device.assert_awaited_once_with(device)
+
+        @pytest.mark.asyncio
+        async def test_calls_upsert_even_same_status(
+            self, subscriber, mock_storage, device
+        ):
+            """
+            Колбек всё равно вызывает upsert при совпадении статусов.
+
+            Логика в subscriber.py не прерывает выполнение
+            при одинаковом статусе — лишь логирует и продолжает.
+            Upsert всё равно вызван.
+            """
+            status = DeviceStatus.ONLINE
+
+            await subscriber.on_device_status_update(device, status, status)
+
+            mock_storage.upsert_device.assert_awaited_once_with(device)
+
+        @pytest.mark.asyncio
+        async def test_does_not_raise_on_storage_error(
+            self, subscriber, mock_storage, device
+        ):
+            """on_device_status_update не пробрасывает исключение."""
+            mock_storage.upsert_device.side_effect = Exception(
+                "connection lost"
+            )
+
+            await subscriber.on_device_status_update(
+                device, DeviceStatus.OFFLINE, DeviceStatus.ONLINE
+            )
+
+        @pytest.mark.asyncio
+        async def test_delete_not_called_on_status_update(
+            self, subscriber, mock_storage, device
+        ):
+            """on_device_status_update не трогает delete_device."""
+            await subscriber.on_device_status_update(
+                device, DeviceStatus.OFFLINE, DeviceStatus.ONLINE
+            )
+
+            mock_storage.delete_device.assert_not_awaited()
+
+    class TestOnDeviceUnregister:
+        """Тесты колбэка on_device_unregister."""
+
+        @pytest.mark.asyncio
+        async def test_calls_delete_device(
+            self,
+            subscriber,
+            mock_storage,
+            device
+        ):
+            """on_device_unregister вызывает storage.delete_device."""
+            await subscriber.on_device_unregister(device)
+
+            mock_storage.delete_device.assert_awaited_once_with(
+                device.device_id
+            )
+
+        @pytest.mark.asyncio
+        async def test_does_not_raise_on_storage_error(
+            self, subscriber, mock_storage, device
+        ):
+            """on_device_unregister не пробрасывает исключение при ошибке."""
+            mock_storage.delete_device.side_effect = RuntimeError("DB gone")
+
+            await subscriber.on_device_unregister(device)
+
+        @pytest.mark.asyncio
+        async def test_upsert_not_called_on_unregister(
+            self, subscriber, mock_storage, device
+        ):
+            """on_device_unregister не трогает upsert_device."""
+            await subscriber.on_device_unregister(device)
+
+            mock_storage.upsert_device.assert_not_awaited()
+
+        @pytest.mark.asyncio
+        async def test_delete_called_with_correct_id(
+            self,
+            subscriber,
+            mock_storage
+        ):
+            """on_device_unregister передаёт именно device_id устройства."""
+            specific_device = Device(
+                device_id="exact-id-999",
+                name="Exact",
+                device_type=DeviceType.ACTUATOR,
+                device_status=DeviceStatus.OFFLINE,
+                protocol=ProtocolType.MQTT,
+            )
+
+            await subscriber.on_device_unregister(specific_device)
+
+            mock_storage.delete_device.assert_awaited_once_with("exact-id-999")


### PR DESCRIPTION
### Описание внесенных изменений

<!-- Короткое описание изменений. -->
Добавлена таблица в хранилище, отвечающая за сохранение информации об устройствах. Помимо хранения в регистре, теперь данные об устройстве поступают туда при помощи колбеков.

### Связанные задачи/проблемы

<!-- Перечисление связанных задач -->

Closes #41 

### Чек-лист

- [x] Проходят тесты
- [x] Выполнен линт

### Дополнительная информация

<!-- Что не вошло в другие -->
